### PR TITLE
Fixed translations when not using lang templates

### DIFF
--- a/report_aeroo/extra_functions.py
+++ b/report_aeroo/extra_functions.py
@@ -212,7 +212,8 @@ class ExtraFunctions(object):
             ('type', '=', 'report'),
             ('src', '=', source),
             ('lang', '=', self.context['lang'] or self.context['user_lang'])
-        ])
+        ], limit=1, order='id desc')
+        trans_value = trans and trans[0] and trans[0]['value'] or False
         if not trans:
             self.env['ir.translation'].create({
                 'src': source,
@@ -221,9 +222,7 @@ class ExtraFunctions(object):
                 'res_id': self.report_id,
                 'name': 'ir.actions.report.xml',
             })
-        return translate(
-            'ir.actions.report.xml', 'report', self._get_lang(), source
-        ) or source
+        return trans_value or source
 
     def _countif(self, attr, domain):
         statement = domain2statement(domain)


### PR DESCRIPTION
Call to translate failed because of missing 'cr' as first arg.

However, the original implementation lead to possible translation
leaks between reports. Indeed, the call to translate does not refer to
any res_id, so translate returned the first report string with the
given source, ignoring the report's ID. This lead to issues since the
same English wording can be translated differently depending on the
context.