### PR TITLE
Improvements on multi-record reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Aeroo Reports for Odoo v10.0
  - Install libreoffice
     - apt-get install libreoffice, libreoffice-writer, openjdk-7-jre
 
+ - Install PDFtk
+    - apt-get install pdftk
 
 ## Translations
 

--- a/report_aeroo/i18n/fr.po
+++ b/report_aeroo/i18n/fr.po
@@ -104,6 +104,11 @@ msgid "Company Evaluation"
 msgstr "Évaluation de la société"
 
 #. module: report_aeroo
+#: model:ir.model.fields,field_description:report_aeroo.field_ir_act_report_xml_process_separately
+msgid "Process Separately"
+msgstr "Traiter séparément"
+
+#. module: report_aeroo
 #: model:ir.model.fields,field_description:report_aeroo.field_report_mimetypes_compatible_types
 msgid "Compatible Mime-Types"
 msgstr "Types compatibles"
@@ -231,6 +236,20 @@ msgstr "Groupes"
 #: model:ir.model.fields,field_description:report_aeroo.field_report_mimetypes_id
 msgid "ID"
 msgstr "ID"
+
+#. module: report_aeroo
+#: model:ir.model.fields,help:report_aeroo.field_ir_act_report_xml_process_separately
+msgid ""
+"If checked the report template will be processed separately "
+"with each record's data and the whole will be merged afterwards "
+"if the output format is PDF. Otherwise, the template will be "
+"processed with all records data at once."
+msgstr ""
+"Si cette case est cochée, le modèle de rapport sera traité "
+"séparément avec les données de chacun des enregistrement et "
+"le tout sera fusionné ensuite si le format de sortie est PDF."
+"Dans le cas contraire, le modèle de rapport sera traité avec "
+"les données de tous les enregistrements."
 
 #. module: report_aeroo
 #: model:ir.ui.view,arch_db:report_aeroo.act_aeroo_report_xml_search_view

--- a/report_aeroo/models/ir_actions_report_xml.py
+++ b/report_aeroo/models/ir_actions_report_xml.py
@@ -66,6 +66,13 @@ class ReportXml(models.Model):
         help="Python expression used to determine the company "
         "of the record being printed in the report.",
         default="o.company_id")
+    process_separately = fields.Boolean(
+        'Process Separately', default=True,
+        help="If checked the report template will be processed separately "
+             "with each record's data and the whole will be merged afterwards "
+             "if the output format is PDF. Otherwise, the template will be "
+             "processed with all records data at once."
+    )
 
     @api.multi
     def get_template(self, record, lang, company):

--- a/report_aeroo/models/ir_actions_report_xml.py
+++ b/report_aeroo/models/ir_actions_report_xml.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 from odoo import models, fields, api, tools, _
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError
 from odoo.report import interface
 from odoo.report.report_sxw import rml_parse
 from openerp.tools.safe_eval import safe_eval
@@ -88,7 +88,7 @@ class ReportXml(models.Model):
         ), None)
 
         if line is None:
-            raise ValidationError(
+            raise UserError(
                 _('Could not render report %s for the company %s in '
                   'lang %s.') % (
                     self.name, company.name, lang))
@@ -133,7 +133,7 @@ class ReportXml(models.Model):
                     class_inst = py_mod.Parser
                 return class_inst
 
-        raise ValidationError(_('Parser not found at: %s') % path)
+        raise UserError(_('Parser not found at: %s') % path)
 
     def _lookup_report(self, name):
         if 'report.' + name in interface.report_int._reports:
@@ -191,7 +191,7 @@ class ReportXml(models.Model):
         else:
             template = self.report_sxw_content
             if not template:
-                raise ValidationError(
+                raise UserError(
                     _('No template found for report %s' % self.report_name))
 
             if self.tml_source == 'database':

--- a/report_aeroo/report_view.xml
+++ b/report_aeroo/report_view.xml
@@ -57,6 +57,7 @@
                             </group>
                             <group string="Miscellaneous">
                                 <field name="multi"/>
+                                <field name="process_separately"/>
                             </group>
                         </page>
                         <page string="Security">

--- a/report_aeroo/tests/test_report_aeroo.py
+++ b/report_aeroo/tests/test_report_aeroo.py
@@ -4,7 +4,7 @@
 
 import os
 import stat
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError
 from odoo.modules import module
 from odoo.tests import common
 
@@ -107,7 +107,7 @@ class TestAerooReport(common.SavepointCase):
         self.report.out_format = self.env.ref(
             'report_aeroo.report_mimetypes_pdf_odt')
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(UserError):
             self.partner.print_report('sample_report', {})
 
     def _set_libreoffice_location(self, filename):
@@ -125,7 +125,7 @@ class TestAerooReport(common.SavepointCase):
         self.report.out_format = self.env.ref(
             'report_aeroo.report_mimetypes_pdf_odt')
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(UserError):
             self.partner.print_report('sample_report', {})
 
     def test_06_libreoffice_finish_after_100s(self):
@@ -136,7 +136,7 @@ class TestAerooReport(common.SavepointCase):
         self.env['ir.config_parameter'].set_param(
             'report_aeroo.libreoffice_timeout', '5')
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(UserError):
             self.partner.print_report('sample_report', {})
 
     def test_07_libreoffice_fail(self):
@@ -147,7 +147,7 @@ class TestAerooReport(common.SavepointCase):
         self.env['ir.config_parameter'].set_param(
             'report_aeroo.libreoffice_timeout', '5')
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(UserError):
             self.partner.print_report('sample_report', {})
 
     def test_08_multicompany_context(self):
@@ -157,7 +157,7 @@ class TestAerooReport(common.SavepointCase):
     def test_09_multicompany_context(self):
         self._create_report_line(self.lang_en, self.company.id)
         self.partner.write({'company_id': self.company_2.id})
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(UserError):
             self.partner.print_report('sample_report', {})
 
     def test_10_multicompany_context(self):
@@ -166,7 +166,7 @@ class TestAerooReport(common.SavepointCase):
 
     def test_11_multicompany_context(self):
         self._create_report_line(self.lang_fr)
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(UserError):
             self.partner.print_report('sample_report', {})
 
     def test_12_sample_report_pdf_with_multiple_export(self):
@@ -185,5 +185,5 @@ class TestAerooReport(common.SavepointCase):
             'report_aeroo.report_mimetypes_pdf_odt')
         partners = self.partner | self.partner_2
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(UserError):
             partners.print_report('sample_report', {})


### PR DESCRIPTION
Added a `process_separately` parameter to define whether we want to
handle multi-records by processing templates separately and merge them
with PDFtk or to process it once by passing a single "objects" list,
like it was possible in the original report_aeroo.

Changed ValidationError to UserError which is more appropriate.

Added need for PDFtk in README.