### PR TITLE
[8.0] ir.actions.todo: remove 'restart' field that doesn't exist

### DIFF
--- a/report_aeroo/installer.xml
+++ b/report_aeroo/installer.xml
@@ -49,7 +49,6 @@
 
     <record id="report_aeroo_installer_todo" model="ir.actions.todo">
         <field name="action_id" ref="action_report_aeroo_installer"/>
-        <field name="restart">always</field>
         <field name="sequence">3</field>
         <field name="type">automatic</field>
     </record>

--- a/report_aeroo/installer.xml
+++ b/report_aeroo/installer.xml
@@ -124,7 +124,6 @@
 
     <record id="docs_config_installer_todo" model="ir.actions.todo">
         <field name="action_id" ref="action_docs_config_installer"/>
-        <field name="restart">always</field>
         <field name="sequence">3</field>
         <field name="type">automatic</field>
     </record>


### PR DESCRIPTION
As you can see in the base module of odoo v8 https://github.com/odoo/odoo/blob/8.0/openerp/addons/base/ir/ir_actions.py#L1072  the 'restart' field doesn't exist on ir.actions.todo